### PR TITLE
Publish build statuses for stage other than 'running' and 'success'

### DIFF
--- a/src/main/java/argelbargel/jenkins/plugins/gitlab_branch_source/actions/GitLabSCMPublishAction.java
+++ b/src/main/java/argelbargel/jenkins/plugins/gitlab_branch_source/actions/GitLabSCMPublishAction.java
@@ -11,12 +11,14 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.scm.api.SCMHead;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -135,7 +137,16 @@ public final class GitLabSCMPublishAction extends InvisibleAction implements Ser
             if (isNamedStageStartNode(node)) {
                 publishBuildStatus(build, metadata, running, getRunningContexts().push(node), "");
             } else if (isStageEndNode(node, getRunningContexts().peekNodeId())) {
-                publishBuildStatus(build, metadata, (node.getError()!=null ? failed : success), getRunningContexts().pop(), "");
+                ErrorAction error = node.getError();
+                if (error != null) {
+                    if (error.getError() instanceof FlowInterruptedException) {
+                        publishBuildStatus(build, metadata, canceled, getRunningContexts().pop(), "");
+                    } else {
+                        publishBuildStatus(build, metadata, failed, getRunningContexts().pop(), "");
+                    }
+                } else {
+                    publishBuildStatus(build, metadata, success, getRunningContexts().pop(), "");
+                }
             }
         }
 

--- a/src/main/java/argelbargel/jenkins/plugins/gitlab_branch_source/actions/GitLabSCMPublishAction.java
+++ b/src/main/java/argelbargel/jenkins/plugins/gitlab_branch_source/actions/GitLabSCMPublishAction.java
@@ -135,7 +135,7 @@ public final class GitLabSCMPublishAction extends InvisibleAction implements Ser
             if (isNamedStageStartNode(node)) {
                 publishBuildStatus(build, metadata, running, getRunningContexts().push(node), "");
             } else if (isStageEndNode(node, getRunningContexts().peekNodeId())) {
-                publishBuildStatus(build, metadata, success, getRunningContexts().pop(), "");
+                publishBuildStatus(build, metadata, (node.getError()!=null ? failed : success), getRunningContexts().pop(), "");
             }
         }
 


### PR DESCRIPTION
Actually noticed that this code doesn't seem to have any possibility to report build status for anything other than success, which seems like a bit of an oversight.

Not sure if this is the best way to do it, or how it would handle things like unstable builds.
Maybe it might've even been better as an issue instead of a PR, but hey.