### PR TITLE
Add org.gitlab.api.models.GitlabUser to hudson.remoting.ClassFilter

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,3 +1,4 @@
 org.gitlab.api.models.GitlabNamespace
 org.gitlab.api.models.GitlabPermission
 org.gitlab.api.models.GitlabProjectAccessLevel
+org.gitlab.api.models.GitlabUser


### PR DESCRIPTION
Analogous to https://github.com/Argelbargel/gitlab-branch-source-plugin/issues/52, I found that trying to serialize `org.gitlab.api.models.GitlabUser` also can lead to the same error.