### PR TITLE
Don't trigger job without changes to branch

### DIFF
--- a/src/main/java/argelbargel/jenkins/plugins/gitlab_branch_source/GitLabSCMSource.java
+++ b/src/main/java/argelbargel/jenkins/plugins/gitlab_branch_source/GitLabSCMSource.java
@@ -68,7 +68,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     }
 
     GitLabSCMSource(GitLabProject project, GitLabSCMSourceSettings sourceSettings) {
-        super(null);
+        setId(project.getPathWithNamespace());
         this.project = project;
         this.sourceSettings = sourceSettings;
         this.hookListener = GitLabSCMWebHook.createListener(this);


### PR DESCRIPTION
Set the SCMSource Id with the GitLabProject pathWithNamespsce so that the job won't keep building when there are no  changes on the branch (for example on periodic organization folder scan).

See also: #45, #101