### PR TITLE
Do not apply include/exclude restrictions to tags

### DIFF
--- a/src/main/java/argelbargel/jenkins/plugins/gitlab_branch_source/SourceHeads.java
+++ b/src/main/java/argelbargel/jenkins/plugins/gitlab_branch_source/SourceHeads.java
@@ -146,15 +146,13 @@ class SourceHeads {
     }
 
     private void retrieveTag(SCMSourceCriteria criteria, @Nonnull SCMHeadObserver observer, String tagName, @Nonnull TaskListener listener) throws IOException, InterruptedException {
-        if (!source.isExcluded(tagName)) {
-            log(listener, Messages.GitLabSCMSource_retrievingTag(tagName));
-            try {
-                GitlabTag tag = api().getTag(source.getProjectId(), tagName);
-                tag.getCommit().getCommittedDate().getTime();
-                observe(criteria, observer, tag, listener);
-            } catch (NoSuchElementException e) {
-                log(listener, Messages.GitLabSCMSource_removedHead(tagName));
-            }
+        log(listener, Messages.GitLabSCMSource_retrievingTag(tagName));
+        try {
+            GitlabTag tag = api().getTag(source.getProjectId(), tagName);
+            tag.getCommit().getCommittedDate().getTime();
+            observe(criteria, observer, tag, listener);
+        } catch (NoSuchElementException e) {
+            log(listener, Messages.GitLabSCMSource_removedHead(tagName));
         }
     }
 
@@ -202,9 +200,7 @@ class SourceHeads {
             for (GitlabTag tag : api().getTags(source.getProjectId())) {
                 checkInterrupt();
 
-                if (!source.isExcluded(tag.getName())) {
-                    observe(criteria, observer, tag, listener);
-                }
+                observe(criteria, observer, tag, listener);
             }
         }
     }


### PR DESCRIPTION
The UI does not make it clear that the include/exclude restrictions also apply to tags.
If we set include to a specific branch, it breaks tag discovery.
To be consistent with the UI, do not apply these restrictions on tags.